### PR TITLE
Fix the meta title that didn't have the subtitle

### DIFF
--- a/src/components/SiteMeta.astro
+++ b/src/components/SiteMeta.astro
@@ -5,7 +5,7 @@ let subtitle = 'Accessible Astro Starter'
 ---
 
 <!-- general meta -->
-<meta name="title" content={title} />
+<meta name="title" content={`${title} - ${subtitle}`} />
 <meta name="description" content={description} />
 <meta name="author" content={author} />
 


### PR DESCRIPTION
Result before fix
```html
<meta content="Home" name="title">
```

Result after fix
```html
<meta content="Home - MyWebsite" name="title">
```