### PR TITLE
Fix build bt removing astro-compress

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,10 @@
 import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import tailwind from '@astrojs/tailwind'
+import compress from 'astro-compress'
 
 // https://astro.build/config
 export default defineConfig({
   compressHTML: true,
-  integrations: [mdx(), tailwind()],
+  integrations: [mdx(), tailwind(), compress()],
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,9 @@
 import { defineConfig } from 'astro/config'
-import compress from 'astro-compress'
 import mdx from '@astrojs/mdx'
 import tailwind from '@astrojs/tailwind'
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [compress(), mdx(), tailwind()],
+  compressHTML: true,
+  integrations: [mdx(), tailwind()],
 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@typescript-eslint/parser": "^5.50.0",
     "accessible-astro-components": "^2.1.0",
     "astro": "^2.0.1",
-    "astro-compress": "1.1.28",
     "astro-icon": "^0.7.3",
     "eslint": "^8.33.0",
     "eslint-plugin-astro": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@typescript-eslint/parser": "^5.50.0",
     "accessible-astro-components": "^2.1.0",
     "astro": "^2.0.1",
+    "astro-compress": "^2.0.6",
     "astro-icon": "^0.7.3",
     "eslint": "^8.33.0",
     "eslint-plugin-astro": "^0.23.0",


### PR DESCRIPTION
`astro-compress` has been deleted by the author, which has broken build a lot of sites & themes. Currently, I'm working through the themes affected by this.

This PR removes it as a dependency & enables [`compressHTML`](https://docs.astro.build/en/reference/configuration-reference/#compresshtml) which provides similar html minification to `astro-compress`.