### PR TITLE
Feature: Update `astro-icon` to v1 and svgo

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,12 @@ import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import tailwind from '@astrojs/tailwind'
 import compress from 'astro-compress'
+import icon from "astro-icon"
 
 // https://astro.build/config
 export default defineConfig({
   compressHTML: true,
-  integrations: [mdx(), tailwind({
+  integrations: [mdx(), icon(), tailwind({
     applyBaseStyles: false,
   }), compress()],
 })

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "@astrojs/mdx": "^2.0.2",
     "@astrojs/partytown": "^2.0.2",
     "@astrojs/tailwind": "^5.0.4",
+    "@iconify-json/ion": "^1.1.15",
+    "@iconify-json/mdi": "^1.1.64",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "accessible-astro-components": "^2.3.3",
     "astro": "^4.0.7",
     "astro-compress": "^2.0.6",
-    "astro-icon": "^0.7.3",
+    "astro-icon": "^1.0.2",
     "eslint": "^8.33.0",
     "eslint-plugin-astro": "^0.23.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -27,7 +29,7 @@
     "prettier-plugin-astro": "^0.8.0",
     "prettier-plugin-tailwindcss": "^0.2.2",
     "sass": "^1.49.9",
-    "svgo": "^2.8.0",
+    "svgo": "^3.2.0",
     "tailwindcss": "^3.2.7"
   }
 }

--- a/src/assets/scss/base/_button.scss
+++ b/src/assets/scss/base/_button.scss
@@ -134,7 +134,7 @@
     align-items: center;
     gap: 0.5rem;
 
-    [astro-icon] {
+    [data-icon] {
       width: 30px;
     }
   }

--- a/src/assets/scss/base/_button.scss
+++ b/src/assets/scss/base/_button.scss
@@ -135,6 +135,7 @@
     gap: 0.5rem;
 
     [data-icon] {
+      height: auto;
       width: 30px;
     }
   }

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -1,5 +1,5 @@
 ---
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 
 const { icon = 'mdi:rocket', title = 'Title' } = Astro.props
 ---

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -54,7 +54,7 @@ const { icon = 'mdi:rocket', title = 'Title' } = Astro.props
     }
   }
 
-  :global(.feature [astro-icon]) {
+  :global(.feature [data-icon]) {
     width: 4rem;
     color: var(--action-color);
   }

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -55,6 +55,7 @@ const { icon = 'mdi:rocket', title = 'Title' } = Astro.props
   }
 
   :global(.feature [data-icon]) {
+    height: auto;
     width: 4rem;
     color: var(--action-color);
   }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -46,6 +46,7 @@ import { Icon } from 'astro-icon/components'
       display: block;
 
       [data-icon] {
+        height: auto;
         margin-top: -4px;
         width: 30px;
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,7 +32,7 @@ import { Icon } from 'astro-icon/components'
     </li>
     <li class="menu-item type-icon">
       <a href="https://github.com/markteekman/accessible-astro-starter" title="Go to the GitHub page">
-        <Icon pack="ion" name="logo-github" />
+        <Icon name="ion:logo-github" />
       </a>
     </li>
   </Navigation>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,7 @@
 ---
 import Navigation from '../components/Navigation.astro'
 import { SkipLinks } from 'accessible-astro-components'
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 ---
 
 <header>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -45,7 +45,7 @@ import { Icon } from 'astro-icon/components'
     .type-icon a {
       display: block;
 
-      [astro-icon] {
+      [data-icon] {
         margin-top: -4px;
         width: 30px;
 
@@ -55,7 +55,7 @@ import { Icon } from 'astro-icon/components'
       }
 
       &:hover {
-        [astro-icon] path {
+        [data-icon] path {
           fill: var(--action-color-state);
         }
       }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,5 +1,5 @@
 ---
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 
 const { src = '/astronaut-hero-img.webp' } = Astro.props
 ---

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -13,14 +13,14 @@ const { src = '/astronaut-hero-img.webp' } = Astro.props
         </h1>
         <div class="flex flex-col gap-3 min-[500px]:flex-row">
           <a class="button has-icon" href="https://github.com/markteekman/accessible-astro-starter">
-            <Icon pack="ion" name="star-outline" />
+            <Icon name="ion:star-outline" />
             Star on GitHub
           </a>
           <a
             class="button has-icon color-secondary"
             href="https://github.com/markteekman/accessible-astro-starter/blob/main/README.md"
           >
-            <Icon pack="ion" name="bookmark-outline" />
+            <Icon name="ion:bookmark-outline" />
             Read the Docs
           </a>
         </div>

--- a/src/pages/accessible-components.astro
+++ b/src/pages/accessible-components.astro
@@ -1,6 +1,6 @@
 ---
 import DefaultLayout from '../layouts/DefaultLayout.astro'
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 import {
   Accordion,
   AccordionItem,

--- a/src/pages/accessible-components.astro
+++ b/src/pages/accessible-components.astro
@@ -112,26 +112,26 @@ import {
         <div class="space-content">
           <h2>Notification</h2>
           <Notification>
-            <Icon pack="ion" name="notifications-outline" /><p><strong>Message:</strong> This is a notification!</p>
+            <Icon name="ion:notifications-outline" /><p><strong>Message:</strong> This is a notification!</p>
           </Notification>
           <Notification type="info">
-            <Icon pack="ion" name="information-circle-outline" /><p>
+            <Icon name="ion:information-circle-outline" /><p>
               <strong>Info:</strong> This is a notification of type info.
             </p>
           </Notification>
           <Notification type="success">
-            <Icon pack="ion" name="checkbox-outline" /><p>
+            <Icon name="ion:checkbox-outline" /><p>
               <strong>Success:</strong> This is a notification of type success.
             </p>
           </Notification>
           <Notification type="warning">
-            <Icon pack="ion" name="warning-outline" /><p>
+            <Icon name="ion:warning-outline" /><p>
               <strong>Warning:</strong> This is a notification of type warning and goes on multiple lines to see how that
               looks.
             </p>
           </Notification>
           <Notification type="error">
-            <Icon pack="ion" name="alert-circle-outline" /><p>
+            <Icon name="ion:alert-circle-outline" /><p>
               <strong>Error:</strong> This is a notification of type error.
             </p>
           </Notification>

--- a/src/pages/mdx-page.mdx
+++ b/src/pages/mdx-page.mdx
@@ -9,7 +9,7 @@ import { Notification } from 'accessible-astro-components'
 # MDX Page
 
 <Notification type="info">
-  <Icon pack="ion" name="information-circle-outline" />
+  <Icon name="ion:information-circle-outline" />
   <p>
     <strong>Info:</strong> This page utilizes Astro's MDX feature which let's you use components in a markdown file and
     supports out-of-the-box syntax highlighting with Shiki.

--- a/src/pages/mdx-page.mdx
+++ b/src/pages/mdx-page.mdx
@@ -3,7 +3,7 @@ layout: ../layouts/MarkdownLayout.astro
 title: MDX Page
 ---
 
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 import { Notification } from 'accessible-astro-components'
 
 # MDX Page


### PR DESCRIPTION
Hello! My compliments to an excellent astro starter repo with great baseline accessibility.

When I first tried out this repo I ran into issues with `svgo` and it's dependency `sharp`.

While troubleshooting the build, I found that `astro-icon` had been updated to v1 with some breaking changes. After updating in my personal project I found the changes to be fairly straightforward and thought to replicate for you on the main repo.

Most of the changes needed are documented in the `astro-icon` upgrade docs: https://www.astroicon.dev/guides/upgrade/v1/

I also needed to make some minor changes to the css styles to match the current site design. These changes are needed as the `astro-icon` now delivers icons with the `width` and `height` props, not previously present on the svg elements.

`package.json` changes:
```
- upgrade astro-icon 0.7.3 => 1.0.2
- upgrade svgo 2.8.0 => 3.2.0
- add @iconify-json/ion
- add @iconify-json/mdi
```
Cheers, and let me know if you have any questions.