### PR TITLE
Remove dead link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,7 +28,7 @@ import { Icon } from 'astro-icon/components'
       </ul>
     </li>
     <li class="menu-item">
-      <a href="https://accessible-astro.dev" title="external link" rel="external noopener noreferrer">External Link</a>
+      <a href="#" title="external link" rel="external noopener noreferrer">External Link</a>
     </li>
     <li class="menu-item type-icon">
       <a href="https://github.com/markteekman/accessible-astro-starter" title="Go to the GitHub page">


### PR DESCRIPTION
`https://accessible-astro.dev` no longer appears valid. This should be replaced with another example external URL.